### PR TITLE
Update requirements to reflect python 3.9 as the max supported version

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -7,7 +7,7 @@ id: requirements
 
 ## Software Requirements
 
- - Python (3.6 or higher) ([Install](https://www.python.org/downloads/))
+ - Python (3.6 to 3.9) ([Install](https://www.python.org/downloads/))
    
 ### Optional requires (based on configuration)
  - Docker ([Install](https://docs.docker.com/get-docker/))


### PR DESCRIPTION
# Pull request

## CLA

- [x] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the Unmanic project and the project 
owner. My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0

## Description of the pull request

Update the requirements file to show that the max python version supported is 3.9.  Currently if you try and run unmanic with python 3.10 you get the following:
`ImportError: cannot import name 'Hashable' from 'collections' (/usr/lib/python3.10/collections/__init__.py) `