### PR TITLE
Fixed "changelog.json" to "changelog.md"

### DIFF
--- a/docs/development/writing_plugins/introduction.mdx
+++ b/docs/development/writing_plugins/introduction.mdx
@@ -28,7 +28,7 @@ my_new_plugin
 
 
 ---
-### File: `changelog.json`
+### File: `changelog.md`
 
 This file should be used to record changes made to the Plugin.
 


### PR DESCRIPTION
The displayed folder structure reads "changelog.md" while the header on this section used to be "changelog.json". This commit fixes this typo (making sure both of them are "changelog.md).