### PR TITLE
proper usage of systemd based on install guidance

### DIFF
--- a/docs/installation/pip.mdx
+++ b/docs/installation/pip.mdx
@@ -29,12 +29,11 @@ unmanic --help
 ```
 
 
-## Automatically starting Unmanic
+## Automatically start Unmanic
 
-You may wish to automatically start Unmanic when you PC starts.
+You may wish to automatically start Unmanic when your system starts.
 
-This can be achieved in a few ways:
-
+This example leverages [systemd's userspace](https://wiki.archlinux.org/title/Systemd/User) in order to be aligned with the install instructions documented above.
 
 <Tabs
   defaultValue="systemd"
@@ -43,52 +42,42 @@ This can be achieved in a few ways:
   ]}>
   <TabItem value="systemd">
 
-Run the following commands as root
-
 ```bash
-mkdir -p \
-/usr/local/lib/systemd/system \
-/opt/unmanic
+sudo mkdir -p /opt/unmanic
+sudo chown $(id -u) /opt/unmatic
+mkdir -p ~/.config/systemd/user
 
-chown -R nobody:video /opt/unmanic
-
-cat << EOF > /usr/local/lib/systemd/system/unmanic.service
+cat << EOF > ~/.config/systemd/user/unmanic.service
 [Unit]
-Description= Unmanic - Library Optimiser
+Description=Unmanic - Library Optimiser
 After=network-online.target
 StartLimitInterval=200
 StartLimitBurst=3
 
 [Service]
 Type=simple
-User=nobody
-Group=video
 Environment="HOME_DIR=/opt/unmanic"
 WorkingDirectory=/opt/unmanic
-ExecStart=/usr/local/bin/unmanic
+ExecStart=%h/.local/bin/unmanic
 Restart=always
 RestartSec=30
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 EOF
 
-systemctl enable unmanic.service
-systemctl start unmanic.service
+systemctl --user enable unmanic.service
+systemctl --user start unmanic.service
 ```
 
-You can view the status of the running process with
+You can view the status of the running process
 ```bash
-systemctl status unmanic.service
+systemctl --user status unmanic.service
 ```
 
-:::note
-This example runs unmanic as the user:group nobody:video.
-Make sure that your library is accessible by this group.
-
-Alternatively, if you already have a user:group configured
-for accessing your library, modify the above systemd unit with those details.
-:::
-
+You can view the logs
+```bash
+journalctl --user -u unmanic.service
+```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Documentation should never assume or advocate people run stuff like this as root. In order to fix this, we can leverage systemd/user. Of course, a dedicated user would be best but this is a step in the right direction. 